### PR TITLE
Installing Yo and generator-opent2t

### DIFF
--- a/gettingStarted/step3.html
+++ b/gettingStarted/step3.html
@@ -45,7 +45,8 @@
             First, install Yeoman and generator-opent2t using npm. Both prefer a global install.
         </p>
 
-<pre><code>$ npm install -g yo generator-opent2t 
+<pre><code>$ npm install --global yo 
+$ npm install --global generator-opent2t
 </code></pre>
 
         <p>


### PR DESCRIPTION
The -g (global) flag for the command, 'npm install -g yo generator-opent2t' was not getting applied properly. So, I have split the command into two, one each for installing Yo (in accordance with the Yeoman website (http://yeoman.io/codelab/setup.html) and generator-opent2t.

How identified?
While trying to create a new translator, the schemas to choose from options was not presented.

How tested?
Installed the Yo and generator-opent2t with the proposed changes on a fresh machine and now I am able to generate translators.
